### PR TITLE
a2jmidid: fix build on aarch64-linux

### DIFF
--- a/pkgs/applications/audio/a2jmidid/default.nix
+++ b/pkgs/applications/audio/a2jmidid/default.nix
@@ -18,12 +18,16 @@ in stdenv.mkDerivation {
 
   patches = [
     (fetchpatch {
-      url = "https://repo.or.cz/a2jmidid.git/patch/24e3b8e543256ae8fdfb4b75eb9fd775f07c46e2";
+      url = https://repo.or.cz/a2jmidid.git/patch/24e3b8e543256ae8fdfb4b75eb9fd775f07c46e2;
       sha256 = "1nxrvnhxlgqc9wbxnp1gnpw4wjyzxvymwcg1gh2nqzmssgfykfkc";
     })
     (fetchpatch {
-      url = "https://repo.or.cz/a2jmidid.git/patch/7f82da7eb2f540a94db23331be98d42a58ddc269";
+      url = https://repo.or.cz/a2jmidid.git/patch/7f82da7eb2f540a94db23331be98d42a58ddc269;
       sha256 = "1nab9zf0agbcj5pvhl90pz0cx1d204d4janqflc5ymjhy8jyrsdv";
+    })
+    (fetchpatch {
+      url = "https://github.com/linuxaudio/a2jmidid/commit/c07775d021a71cb91bf64ce1391cf525415cb060.diff";
+      sha256 = "172v9hri03qdqi8a3zsg227k5qxldd8v5bj4jk7fyk5jf50fcxga";
     })
   ];
 
@@ -35,6 +39,6 @@ in stdenv.mkDerivation {
     description = "Daemon for exposing legacy ALSA sequencer applications in JACK MIDI system";
     license = licenses.gpl2;
     maintainers = [ maintainers.goibhniu ];
-    platforms = [ "i686-linux" "x86_64-linux" ];
+    platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" ];
   };
 }


### PR DESCRIPTION
I just cherrypicked a patch from the github repo.

This fixes the jack-service on aarch64 indirectly as well, which is why I needed it.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).
